### PR TITLE
bugfix: rename host and containername of superset-worker-beat

### DIFF
--- a/modern-data-platform-stack/generator-config/templates/docker-compose.yml.j2
+++ b/modern-data-platform-stack/generator-config/templates/docker-compose.yml.j2
@@ -4179,8 +4179,8 @@ services:
 
   superset-worker-beat:
     image: apache/superset:{{__SUPERSET_version}}
-    hostname: superset-worker
-    container_name: superset-worker
+    hostname: superset-worker-beat
+    container_name: superset-worker-beat
     user: "root"
     environment:
       - DATABASE_DB=superset


### PR DESCRIPTION
I get a name conflict when starting up a superset config.
I guess this should fix this, but I am not sure if there are any side effects...